### PR TITLE
Forward declare edit-distance

### DIFF
--- a/src/fuzzy_matcher/core.clj
+++ b/src/fuzzy_matcher/core.clj
@@ -2,7 +2,7 @@
       :author "Smit Shah <who828@gmail.com>"}
   fuzzy-matcher.core)
 
-(declare min-edit-distance)
+(declare min-edit-distance edit-distance)
 
 (defn- edit-distance* [t p]
   (cond


### PR DESCRIPTION
Forgot to forward-declare `edit-distance` in the last commit.
